### PR TITLE
Index pattern updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,10 @@
     },
     "dependencies": {
         "elasticsearch": "^14.2.1",
+        "moment": "^2.24.0",
         "pip-services3-commons-node": "^3.0.0",
         "pip-services3-components-node": "^3.0.0",
-        "pip-services3-rpc-node": "^3.0.0"
+        "pip-services3-rpc-node": "^3.2.1"
     },
     "devDependencies": {
         "@types/async": "^2.0.0",

--- a/test/log/ElasticSearchLogger.test.ts
+++ b/test/log/ElasticSearchLogger.test.ts
@@ -3,13 +3,17 @@ import { ConfigParams } from 'pip-services3-commons-node';
 import { ElasticSearchLogger } from '../../src/log/ElasticSearchLogger';
 import { LoggerFixture } from '../fixtures/LoggerFixture';
 
-suite('ElasticSearchLogger', ()=> {
+let assert = require('chai').assert;
+let async = require('async');
+
+suite('ElasticSearchLogger', () => {
     let _logger: ElasticSearchLogger;
     let _fixture: LoggerFixture;
 
     setup((done) => {
         let host = process.env['ELASTICSEARCH_SERVICE_HOST'] || 'localhost';
         let port = process.env['ELASTICSEARCH_SERVICE_PORT'] || 9200;
+        let dateFormat: string = "YYYYMMDD";
 
         _logger = new ElasticSearchLogger();
         _fixture = new LoggerFixture(_logger);
@@ -18,13 +22,14 @@ suite('ElasticSearchLogger', ()=> {
             'source', 'test',
             'index', 'log',
             'daily', true,
+            "date_format", dateFormat,
             'connection.host', host,
             'connection.port', port
         );
         _logger.configure(config);
 
         _logger.open(null, (err) => {
-             done(err);
+            done(err);
         });
     });
 
@@ -42,6 +47,70 @@ suite('ElasticSearchLogger', ()=> {
 
     test('Error Logging', (done) => {
         _fixture.testErrorLogging(done);
+    });
+
+    /**
+     * We test to ensure that the date pattern does not effect the opening of the elasticsearch component
+     */
+    test('Date Pattern Testing - YYYY.MM.DD', (done) => {
+
+        let host = process.env['ELASTICSEARCH_SERVICE_HOST'] || 'localhost';
+        let port = process.env['ELASTICSEARCH_SERVICE_PORT'] || 9200;
+
+        let logger = new ElasticSearchLogger();
+        let dateFormat: string = "YYYY.MM.DD";
+
+        let config = ConfigParams.fromTuples(
+            'source', 'test',
+            'index', 'log',
+            'daily', true,
+            "date_format", dateFormat,
+            'connection.host', host,
+            'connection.port', port
+        );
+        logger.configure(config);
+
+        logger.open(null, (err) => {
+            if (err) {
+                done(err);
+            }
+
+            // Since the currentIndex property is private, we will just check for an open connection
+            assert.isTrue(logger.isOpen());
+            logger.close(null, done);
+        });
+    });
+
+    /**
+     * We test to ensure that the date pattern does not effect the opening of the elasticsearch component
+     */
+    test('Date Pattern Testing - YYYY.M.DD', (done) => {
+
+        let host = process.env['ELASTICSEARCH_SERVICE_HOST'] || 'localhost';
+        let port = process.env['ELASTICSEARCH_SERVICE_PORT'] || 9200;
+
+        let logger = new ElasticSearchLogger();
+        let dateFormat: string = "YYYY.M.DD";
+
+        let config = ConfigParams.fromTuples(
+            'source', 'test',
+            'index', 'log',
+            'daily', true,
+            "date_format", dateFormat,
+            'connection.host', host,
+            'connection.port', port
+        );
+        logger.configure(config);
+
+        logger.open(null, (err) => {
+            if (err) {
+                done(err);
+            }
+
+            // Since the currentIndex property is private, we will just check for an open connection
+            assert.isTrue(logger.isOpen());
+            logger.close(null, done);
+        });
     });
 
 });


### PR DESCRIPTION
Implemented a configurable date format for the elasticsearch index pattern.

I have updated the code to get the date_format from the config file or default it to YYYYMMDD.
See momentjs formats here - https://momentjs.com/docs/#/displaying/format/
I have added tests for this change.

Related PR
I have added updates to the RPC package, to allow for a HTTPS connection with no security credentials, when using the internal_network flag
See the PR for this change here - https://github.com/pip-services3-node/pip-services3-rpc-node/pull/1